### PR TITLE
a foundation for capped collections implementation

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
@@ -27,10 +27,11 @@ public interface MongoBackend {
 
     void dropDatabase(String database) throws MongoServerException;
 
+    void convertToCapped(String databaseName, String collectionNamed, Integer maxDocuments, Integer byteSize) throws MongoServerException;
+
     Collection<Document> getCurrentOperations(MongoQuery query);
 
     List<Integer> getVersion();
 
     void close();
-
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
@@ -29,6 +29,7 @@ public class ReadOnlyProxy implements MongoBackend {
         allowedCommands.add("serverstatus");
         allowedCommands.add("buildinfo");
         allowedCommands.add("getlasterror");
+        allowedCommands.add("convertToCapped");
     }
 
     private MongoBackend backend;
@@ -94,6 +95,11 @@ public class ReadOnlyProxy implements MongoBackend {
     @Override
     public void dropDatabase(String database) throws MongoServerException {
         throw new ReadOnlyException("dropping of databases is not allowed");
+    }
+
+    @Override public void convertToCapped(String databaseName, String collectionNamed, Integer maxDocuments,
+            Integer byteSize) throws MongoServerException {
+        throw new ReadOnlyException("capping of database collections is not allowed");
     }
 
     @Override

--- a/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgreSqlMongoServer.java
+++ b/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgreSqlMongoServer.java
@@ -1,0 +1,7 @@
+package de.bwaldvogel.mongo.backend.postgresql;
+
+/**
+ * Created by gburd on 4/25/17.
+ */
+public class PostgreSqlMongoServer {
+}

--- a/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlBackend.java
+++ b/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlBackend.java
@@ -26,12 +26,15 @@ public class PostgresqlBackend extends AbstractMongoBackend {
     protected MongoDatabase openOrCreateDatabase(String databaseName) throws MongoServerException {
         String sql = "CREATE TABLE IF NOT EXISTS " + databaseName + "._meta" +
             " (collection_name text," +
-            "  datasize bigint," +
+                "  datasize bigint default 0 not null," +
+                "  is_capped boolean default false not null," +
+                "  capped_to_byte_size int," +
+                "  capped_to_document_count int," +
             " CONSTRAINT pk_meta PRIMARY KEY (collection_name)" +
             ")";
         try (Connection connection = getConnection();
-             PreparedStatement stmt1 = connection.prepareStatement("CREATE SCHEMA IF NOT EXISTS " + databaseName);
-             PreparedStatement stmt2 = connection.prepareStatement(sql)
+                PreparedStatement stmt1 = connection.prepareStatement("CREATE SCHEMA IF NOT EXISTS " + databaseName);
+                PreparedStatement stmt2 = connection.prepareStatement(sql)
         ) {
             stmt1.executeUpdate();
             stmt2.executeUpdate();
@@ -44,6 +47,24 @@ public class PostgresqlBackend extends AbstractMongoBackend {
 
     public Connection getConnection() throws SQLException {
         return dataSource.getConnection();
+    }
+
+    @Override
+    public void convertToCapped(String databaseName, String collectionNamed, Integer maxDocuments, Integer byteSize)
+            throws MongoServerException {
+        String sql = "UPDATE " + databaseName  + "._meta " +
+                     "SET is_capped = true, " +
+                     "    capped_to_byte_size = " + byteSize.toString() + ", " +
+                     "    capped_to_document_count = " + maxDocuments.toString() + " " +
+                     "WHERE collection_name = '" + collectionNamed + "'";
+
+        try (Connection connection = getConnection();
+                PreparedStatement stmt = connection.prepareStatement(sql)
+        ) {
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new MongoServerException("failed to open or create database", e);
+        }
     }
 
 }


### PR DESCRIPTION
Creating a collection with the capped option or converting an existing collection to be capped won't throw an error anymore.  In the Pg backend the limits are recorded in the meta database.

closes #2 